### PR TITLE
fix switch indent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,11 +32,11 @@ AlignConsecutiveMacros:
   AlignFunctionPointers: false
   PadOperators: false
 AlignConsecutiveShortCaseStatements:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCaseArrows: false
-  AlignCaseColons: false
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCaseArrows: true
+  AlignCaseColons: true
 AlignConsecutiveTableGenBreakingDAGArgColons:
   Enabled: false
   AcrossEmptyLines: false
@@ -67,8 +67,8 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: Never
 AllowShortBlocksOnASingleLine: Always
-AllowShortCaseExpressionOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
+AllowShortCaseExpressionOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: None
@@ -278,4 +278,3 @@ KeepEmptyLinesAtTheStartOfBlocks: true
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-


### PR DESCRIPTION
before
```c
switch (code) {
        case 0: return ' ';
        case 1: return '*';
        case 2: return '\0';
    }
```
after
```c
switch (code) {
        case 0:
            return ' ';
        case 1:
            return '*';
        case 2:
            return '\0';
    }
```